### PR TITLE
Adds alternate source for SQS-specific AWS credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+- Optionally use HUBOT_SQS_AWS_ACCESS_KEY_ID and HUBOT_SQS_SECRET_ACCESS_KEY instead of default aws-sdk environment variables.
+
 ### 0.1.2
 - Use AWS_REGION to set region
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ e.g.: `https://sqs.us-east-1.amazonaws.com/885581794223/hubot-queue`
 
 ### AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 
-AWS-related environment variables are required to be set correctly, so that the bot can access the queue specified above with HUBOT_SQS_QUEUE_URL.
+AWS-related environment variables are required to be set correctly, so that the bot can access the queue specified above with HUBOT_SQS_QUEUE_URL. If you prefer to provide a specific set of AWS credentials for use with this script alone, you can instead define HUBOT_SQS_AWS_ACCESS_KEY_ID and HUBOT_SQS_AWS_SECRET_ACCESS_KEY.
 
 ### AWS_REGION
 

--- a/src/scripts/incoming-sqs.coffee
+++ b/src/scripts/incoming-sqs.coffee
@@ -13,7 +13,11 @@ module.exports = (robot) ->
     robot.logger.error "Disabling incoming-sqs plugin because HUBOT_SQS_QUEUE_URL is not set."
     return
 
-  sqs = new AWS.SQS { region: process.env.AWS_REGION ? 'us-east-1' }
+  sqs = new AWS.SQS {
+    region: process.env.AWS_REGION ? 'us-east-1'
+    accessKeyId: process.env.HUBOT_SQS_AWS_ACCESS_KEY_ID
+    secretAccessKey: process.env.HUBOT_SQS_SECRET_ACCESS_KEY
+  }
 
   receiver = (sqs, queue) ->
     robot.logger.debug "Fetching from #{queue}"


### PR DESCRIPTION
When using this plugin with other hubot plugins it might be useful or necessary to use a separate set of AWS credentials that have the specific SQS permissions needed. Currently this plugin uses the default credential configuration supported by aws-sdk (environment variable or credentials stored in a file like ~/.aws/credentials).

This PR adds an additional method of providing alternate credentials solely for SQS, by defining these variables:

- `HUBOT_SQS_AWS_ACCESS_KEY_ID`
- `HUBOT_SQS_SECRET_ACCESS_KEY`

If these are defined, they'll be passed into the AWS.SQS instance and used for communication with SQS. If not defined, the default aws-sdk credential locations will be checked.

This naming convention is similar to how other packages like [hubot-s3-brain](https://github.com/dylanmei/hubot-s3-brain#readme) name their credential environment variables.

This commit also modifies the README and CHANGELOG.md in anticipation of a future release.